### PR TITLE
docs: improve README folder structure formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ Each level contains its own `README.md` with topic-wise structure and references
 
 ## 📂 Folder Structure
 
+```text
 Fellowship-2025-DSA-Series/
-├── Pre-Requisites/ # ✅ Start here — Basics of C++, Math, and Complexity
-│ └── README.md
-├── Level 0/ # Arrays, Strings, Recursion....
-│ └── README.md
-├── Level 1/ # Arrays, Strings, Recursion....
-│ └── README.md
-├── Common/ # Shared templates, math utils , Templates
-└── README.md # This file
-
+├── Pre-Requisites/  # Basics of C++, Math, and Complexity
+│   └── README.md
+├── Level 0/         # Core DSA Patterns (Arrays, Strings, Hashmaps, Trees, Recursion...)
+├── Level 1/         # Advanced DSA Topics organized week-wise (Week 01 - Week 16)
+│   └── README.md
+├── Common/          # Shared templates, utilities, and resources
+└── README.md
+```
 
 ## 🧪 How to Practice
 


### PR DESCRIPTION
## Related Issue

Closes #46

## Changes Made

* Reformatted the folder structure section in the README using a proper code block.
* Improved readability of the repository hierarchy.
* Added concise descriptions for the main directories.
* Prevented the folder tree from rendering as a wrapped single line.

## Why

The previous folder structure was difficult to read because the tree formatting was not preserved, making it hard for contributors to understand the repository layout.

This update improves navigation and onboarding while keeping the structure concise and maintainable.


## Before

* Folder hierarchy was difficult to distinguish.
* Tree structure wrapped across multiple lines.
* Repository organization was not immediately clear.
<img width="638" height="135" alt="image" src="https://github.com/user-attachments/assets/0a319685-a381-4e11-9019-ea9ee20f54e4" />

## After

* Clear hierarchical folder tree.
* Better readability on GitHub.
* Easier for new contributors to understand the project structure.

<img width="647" height="198" alt="image" src="https://github.com/user-attachments/assets/4cecaeb1-1384-4115-bd92-1850404854c9" />

